### PR TITLE
[sc-195034] Fix: last modified info incorrectly set when applying List Contents on OneDrive Folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Version 1.1.1](https://github.com/dataiku/dss-plugin-onedrive/releases/tag/v1.1.1) - Bugfix release - 2024-07-22
+
+- Fix last modified information when listing contents of a OneDrive folder 
+
 ## [Version 1.1.0](https://github.com/dataiku/dss-plugin-onedrive/releases/tag/v1.1.0) - Feature and bugfix release - 2023-05-26
 
 - List directory content past 200 items

--- a/plugin.json
+++ b/plugin.json
@@ -1,10 +1,10 @@
 {
     "id": "onedrive",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "meta": {
         "label": "OneDrive",
         "description": "Read and write data from/to your OneDrive account",
-        "author": "Dataiku (Alex Bourret)",
+        "author": "Dataiku",
         "icon": "icon-cloud",
         "tags": [
             "Connector",

--- a/python-fs-providers/onedrive_onedrive-fs/fs-provider.py
+++ b/python-fs-providers/onedrive_onedrive-fs/fs-provider.py
@@ -165,7 +165,8 @@ class OneDriveFSProvider(FSProvider):
             else:
                 paths.append({
                     DSSConstants.PATH: self.get_lnt_path(path + "/" + onedrive_child.get_name()),
-                    DSSConstants.SIZE: onedrive_child.get_size()
+                    DSSConstants.SIZE: onedrive_child.get_size(),
+                    DSSConstants.LAST_MODIFIED: onedrive_child.get_last_modified(),
                 })
                 if first_non_empty:
                     return paths


### PR DESCRIPTION
## Overview

Card: [195034](https://app.shortcut.com/dataiku/story/195034/onedrive-plugin-fix-last-modified-info-incorrectly-set-when-applying-list-contents-on-onedrive-folder)

## Local setup

Following ref-doc: https://www.dataiku.com/product/plugins/onedrive/
- Connecting with your company/Azure account, then create an application as described
- The redirect URI can be: `http://localhost:8082/dip/api/oauth2-callback`

Setup in DSS preset:
- Paste your Azure `Application (client) ID` in the `Client ID` field
- Paste your Azure secret `Value` in the `Client secret` field

## Demo

<details>
  <summary>BEFORE fix</summary>


https://github.com/user-attachments/assets/09a80235-a84c-4ed8-ab98-57ceb2bedb9d



</details>

<details>
  <summary>AFTER fix</summary>

https://github.com/user-attachments/assets/0c77bd18-58b5-4c66-882c-c47e3bc77734




</details>

