### PR TITLE
[sc-330839][onedrive] Adds supported Python versions 3.11, 3.12, 3.13, 3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.2.0 - Enhancement release - 2026-07-20
+
+- Added supported Python versions: 3.11, 3.12, 3.13, 3.14
+
 ## [Version 1.1.2](https://github.com/dataiku/dss-plugin-onedrive/releases/tag/v1.1.2) - Bugfix release - 2025-11-21
 
 - Fix access to shared folders

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,14 +1,18 @@
 {
-    "acceptedPythonInterpreters": [
-        "PYTHON35",
-        "PYTHON36",
-        "PYTHON37",
-        "PYTHON38",
-        "PYTHON39",
-        "PYTHON310"
-    ],
-    "corePackagesSet": "AUTO",
-    "forceConda": false,
-    "installCorePackages": true,
-    "installJupyterSupport": false
+  "acceptedPythonInterpreters": [
+    "PYTHON35",
+    "PYTHON36",
+    "PYTHON37",
+    "PYTHON38",
+    "PYTHON39",
+    "PYTHON310",
+    "PYTHON311",
+    "PYTHON312",
+    "PYTHON313",
+    "PYTHON314"
+  ],
+  "corePackagesSet": "AUTO",
+  "forceConda": false,
+  "installCorePackages": true,
+  "installJupyterSupport": false
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,15 +1,19 @@
 {
-    "id": "onedrive",
-    "version": "1.1.2",
-    "meta": {
-        "label": "OneDrive",
-        "description": "Read and write data from/to your OneDrive account",
-        "author": "Dataiku",
-        "icon": "icon-cloud",
-        "category": "Productivity",
-        "tags": ["Connector", "Productivity", "Microsoft"],
-        "url": "https://www.dataiku.com/dss/plugins/info/onedrive.html",
-        "licenseInfo": "Apache Software License",
-        "supportLevel": "NOT_SUPPORTED"
-    }
+  "id": "onedrive",
+  "version": "1.2.0",
+  "meta": {
+    "label": "OneDrive",
+    "description": "Read and write data from/to your OneDrive account",
+    "author": "Dataiku",
+    "icon": "icon-cloud",
+    "category": "Productivity",
+    "tags": [
+      "Connector",
+      "Productivity",
+      "Microsoft"
+    ],
+    "url": "https://www.dataiku.com/dss/plugins/info/onedrive.html",
+    "licenseInfo": "Apache Software License",
+    "supportLevel": "NOT_SUPPORTED"
+  }
 }


### PR DESCRIPTION
## ⚠️⚠️⚠️ From an automated update script ⚠️⚠️⚠️

- Support level: `NOT_SUPPORTED`
- Added supported Python versions: `3.11, 3.12, 3.13, 3.14`
- Bumped plugin version: `1.2.0`

## Details:
### - Tests on Deployer 14.7.1:
 - Creation of Python 3.11 code-env: ✅
 - Creation of Python 3.12 code-env: ✅
 - Creation of Python 3.13 code-env: ✅
 - Creation of Python 3.14 code-env: ✅
### - Tests on Daily master:
 - Creation of Python 3.11 code-env: ✅
 - Creation of Python 3.12 code-env: ✅
 - Creation of Python 3.13 code-env: ✅
 - Creation of Python 3.14 code-env: ✅